### PR TITLE
[ Chore ] Add link to announcement blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Axonius-Panther-Helper
 
-This repository contains a set of custom helpers designed to facilitate integration between Panther SIEM and Axonius. These custom helpers provide a variety of functions for user and device search operations that can be used to leverage the Axonius API.
+This repository contains a set of custom helpers designed to facilitate integration between Panther SIEM and Axonius (initially announced in [a blog post](https://www.axonius.com/blog/integrating-axonius-asset-inventory-panther-real-time-detections-caasm-siem-enrichment)). These custom helpers provide a variety of functions for user and device search operations that can be used to leverage the Axonius API.
 
 ## Table of Contents
 


### PR DESCRIPTION
Since the blog post is live [here](https://www.axonius.com/blog/integrating-axonius-asset-inventory-panther-real-time-detections-caasm-siem-enrichment), I'm adding a reference to it from the README here for further context.