### PR TITLE
[improvement] user_ip_association sublist iteration

### DIFF
--- a/custom_axonius_helpers.py
+++ b/custom_axonius_helpers.py
@@ -300,11 +300,15 @@ def user_ip_association(ip_address: str, username: str) -> bool:
         True of this IP address is related to the user else it returns False.
     """
     ax_ip = find_ip(ip_address)
-    if not ax_ip.get("ERROR") and (
-        username in (item for sublist in ax_ip.get("users") for item in sublist)
-        or username in ax_ip.get("users")
-    ):
-        return True
+    if not ax_ip.get("ERROR"):
+        for sublist in ax_ip.get("users"):
+            if isinstance(sublist, list):
+                for _sub_item in sublist:
+                    if username in _sub_item:
+                        return True
+            else:
+                if username in sublist:
+                    return True
     return False
 
 


### PR DESCRIPTION
This PR is replacing the way `user_ip_association` function iterates over the response from `find_ip`.
This change will make it more efficient and more readable.

Thanks to @alex-lavre that suggested that change.